### PR TITLE
make inputboxes have an min-width

### DIFF
--- a/tellstick/tellstick-input.html
+++ b/tellstick/tellstick-input.html
@@ -89,6 +89,7 @@
 
 .manual-inputs .form-row input {
     width: calc(100% - 120px);
+    min-width: 4em;
 }
 
 .listen-button-listen {


### PR DESCRIPTION
I have a laptop with  1366x768 resolution and the input boxes in the tellstick-input dialog was unreadable.
Made them have a min-width so it's usable at least.